### PR TITLE
Fixing NullReferenceException because of readStringUntil

### DIFF
--- a/examples/Example4-ProcessingHeatCam/HeatCam/HeatCam.pde
+++ b/examples/Example4-ProcessingHeatCam/HeatCam/HeatCam.pde
@@ -72,6 +72,11 @@ void draw() {
   if(myPort.available() > 64){
   myString = myPort.readStringUntil(13);
   
+  // readStringUntil is a non-blocking function and will return null if it can't find the linefeed
+  if(myString == null){
+    return;
+  }
+  
   // generate an array of strings that contains each of the comma
   // separated values
   String splitString[] = splitTokens(myString, ",");


### PR DESCRIPTION
1) readStringUntil [isn't a blocking method and will return null if it can't find 13](https://github.com/arduino/ArduinoCore-avr/blob/9f8d27f09f3bbd1da1374b5549a82bda55d45d44/cores/arduino/Stream.cpp#L245)
2) 64 is like 1/6 of the size of the packet we are waiting (Arduino serialize float as 00.00 (so 5 characters) + the comma separator, so we could easily end up calling readStringUntil way too early.