### PR TITLE
Tiny Stability Update

### DIFF
--- a/examples/Example4-ProcessingHeatCam/HeatCam/HeatCam.pde
+++ b/examples/Example4-ProcessingHeatCam/HeatCam/HeatCam.pde
@@ -71,7 +71,10 @@ void draw() {
   // read everything up to the first linefeed
   if(myPort.available() > 64){
   myString = myPort.readStringUntil(13);
-  
+  if(myString==null){
+    print("\nSerial read returned null \n");
+    return;
+  }
   // generate an array of strings that contains each of the comma
   // separated values
   String splitString[] = splitTokens(myString, ",");


### PR DESCRIPTION
Really small change, sometimes readStringUntil() will return null with the example code and cause the processing application to hang. Adding a simple if statement will drop the frame and alert the user in the console of the issue so the demo can continue to run. 

Tested working with ESP32 + GridEYE + Latest Processing 3.5.4.